### PR TITLE
feat: InstanceTrigger

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "moonshine-kind"
 version = "0.4.1"
-edition = "2021"
+edition = "2024"
 license = "MIT"
 description = "Simple type safety solution for Bevy"
 categories = ["game-development"]
@@ -12,9 +12,9 @@ repository = "https://github.com/Zeenobit/moonshine_kind"
 
 [dependencies]
 disqualified = "1"
-bevy_ecs = "0.17"
-bevy_reflect = "0.17"
-bevy_utils = "0.17"
+bevy_ecs = { version = "0.18.0-dev", default-features=false, git = "https://github.com/mrchantey/bevy", branch="event-from-entity" }
+bevy_reflect = { version = "0.18.0-dev", default-features=false, git = "https://github.com/mrchantey/bevy", branch="event-from-entity" }
+bevy_utils = { version = "0.18.0-dev", default-features=false, git = "https://github.com/mrchantey/bevy", branch="event-from-entity" }
 
 [dev-dependencies]
-bevy = "0.17"
+bevy = { version = "0.18.0-dev", default-features=false, git = "https://github.com/mrchantey/bevy", branch="event-from-entity" }

--- a/examples/instance_events.rs
+++ b/examples/instance_events.rs
@@ -1,0 +1,69 @@
+use std::marker::PhantomData;
+
+use bevy::prelude::*;
+use moonshine_kind::prelude::*;
+
+/// Represents an Apple. Apples are crunchy!
+#[derive(Component)]
+struct Apple;
+
+/// Represents an Orange. Oranges are juicy!
+#[derive(Component)]
+struct Orange;
+
+/// Triggered on a fruit when a hungry human gobbles it all up.
+/// This event will only fire if the entity it was triggered on
+/// contains the provided [`T`] component.
+#[derive(Event)]
+#[event(trigger=InstanceTrigger<Self, &'static ChildOf, T>)]
+struct GobbleGobble<T: Component> {
+    phantom: PhantomData<T>,
+}
+impl<T: Component> Default for GobbleGobble<T> {
+    fn default() -> Self {
+        Self {
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<T: Component> EventFromEntity for GobbleGobble<T> {}
+impl<T: Component> IntoEventFromEntity<Self> for GobbleGobble<T> {
+    type Event = Self;
+    type Trigger = InstanceTrigger<Self, &'static ChildOf, T>;
+
+    fn into_event_from_entity(self, entity: Entity) -> (Self::Event, Self::Trigger) {
+        (self, InstanceTrigger::new(entity, true))
+    }
+}
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_systems(Startup, setup)
+        .run();
+}
+
+fn setup(mut commands: Commands) {
+    commands
+        .spawn(Apple)
+        .observe(|_ev: On<GobbleGobble<Apple>>| {
+            println!("the grandparent apple was gobbled up");
+        })
+        .with_children(|parent| {
+            parent
+                .spawn(Orange)
+                .observe(|_ev: On<GobbleGobble<Orange>>| {
+                    // the orange will be skipped, it is not a match
+                    println!("the parent orange was gobbled up");
+                })
+                .with_children(|parent| {
+                    parent
+                        .spawn(Apple)
+                        .observe(|_ev: On<GobbleGobble<Apple>>| {
+                            println!("the grandchild apple was gobbled up");
+                        })
+                        .trigger(GobbleGobble::<Apple>::default());
+                });
+        });
+}

--- a/examples/instance_events.rs
+++ b/examples/instance_events.rs
@@ -1,3 +1,5 @@
+//! This example demonstrates usage of a custom entity event
+//! that does not rely on `EntityEvent` for ergonomics and type safety.
 use std::marker::PhantomData;
 
 use bevy::prelude::*;

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -21,7 +21,7 @@ use bevy_ecs::{
     system::EntityCommands,
     world::unsafe_world_cell::UnsafeWorldCell,
 };
-use bevy_reflect::{Reflect, prelude::ReflectDefault};
+use bevy_reflect::Reflect;
 
 use crate::{Any, CastInto, Kind};
 

--- a/src/instance_trigger.rs
+++ b/src/instance_trigger.rs
@@ -9,8 +9,8 @@ use std::{fmt, marker::PhantomData};
 
 /// A custom trigger for events targeting an [`Instance`], differing from the default
 /// [`EntityEvent`] / [`PropagateEntityTrigger`] pair in two ways:
-///
-///
+/// - the `event_target` is stored on the [`Trigger`] to avoid unsafe mutations to an [`Instance`]
+/// - event firing and propagation is conditional on the `event_target` containing the provided [`K`] component
 pub struct InstanceTrigger<E: Event, T: Traversal<E>, K: Component> {
     /// The original [`Entity`] the [`Event`] was _first_ triggered for.
     pub original_event_target: Entity,

--- a/src/instance_trigger.rs
+++ b/src/instance_trigger.rs
@@ -1,0 +1,125 @@
+use bevy_ecs::{
+    event::{Trigger, trigger_entity_internal},
+    observer::{CachedObservers, TriggerContext},
+    prelude::*,
+    traversal::Traversal,
+    world::DeferredWorld,
+};
+use std::{fmt, marker::PhantomData};
+
+/// A custom trigger for events targeting an [`Instance`], differing from the default
+/// [`EntityEvent`] / [`PropagateEntityTrigger`] pair in two ways:
+///
+///
+pub struct InstanceTrigger<E: Event, T: Traversal<E>, K: Component> {
+    /// The original [`Entity`] the [`Event`] was _first_ triggered for.
+    pub original_event_target: Entity,
+    /// [`Entity`] the [`Event`] is _currently_ triggered for.
+    pub event_target: Entity,
+
+    /// Whether or not to continue propagating using the `T` [`Traversal`]. If this is false,
+    /// The [`Traversal`] will stop on the current entity.
+    pub propagate: bool,
+
+    _marker: PhantomData<(E, T, K)>,
+}
+
+impl<E: Event, T: Traversal<E>, K: Component> InstanceTrigger<E, T, K> {
+    /// Create a new [`InstanceTrigger`] with the specified component.
+    pub fn new(event_target: Entity, propagate: bool) -> Self {
+        Self {
+            original_event_target: event_target,
+            event_target,
+            propagate,
+            _marker: Default::default(),
+        }
+    }
+}
+
+impl<E: Event, T: Traversal<E>, K: Component> fmt::Debug for InstanceTrigger<E, T, K> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("InstanceTrigger")
+            .field("original_event_target", &self.original_event_target)
+            .field("propagate", &self.propagate)
+            .field("kind", &std::any::type_name::<K>())
+            .field("_marker", &self._marker)
+            .finish()
+    }
+}
+
+// SAFETY:
+// - `E`'s [`Event::Trigger`] is constrained to [`InstanceTrigger<E>`]
+unsafe impl<E: for<'a> Event<Trigger<'a> = Self>, T: Traversal<E>, K: Component> Trigger<E>
+    for InstanceTrigger<E, T, K>
+{
+    unsafe fn trigger(
+        &mut self,
+        mut world: DeferredWorld,
+        observers: &CachedObservers,
+        trigger_context: &TriggerContext,
+        event: &mut E,
+    ) {
+        if !world.entity(self.event_target).contains::<K>() {
+            // here you can insert custom error handling as required
+            panic!(
+                "the triggered entity is not of kind {}",
+                std::any::type_name::<K>()
+            )
+        }
+        // let kind_query = world.query()
+        // SAFETY:
+        // - `observers` come from `world` and match the event type `E`, enforced by the call to `trigger`
+        // - the passed in event pointer comes from `event`, which is an `Event`
+        // - `trigger` is a matching trigger type, as it comes from `self`, which is the Trigger for `E`
+        // - `trigger_context`'s event_key matches `E`, enforced by the call to `trigger`
+
+        unsafe {
+            let target = self.event_target;
+            trigger_entity_internal(
+                world.reborrow(),
+                observers,
+                event.into(),
+                self.into(),
+                target,
+                trigger_context,
+            );
+        }
+
+        loop {
+            if !self.propagate {
+                return;
+            }
+            if let Ok(entity) = world.get_entity(self.event_target)
+                && let Some(item) = entity.get_components::<T>()
+                && let Some(traverse_to) = T::traverse(item, event)
+            {
+                self.event_target = traverse_to;
+            } else {
+                break;
+            }
+            if !world.entity(self.event_target).contains::<K>() {
+                println!("skipped ancestor, does not match");
+                // here i'm deciding to 'jump over' ancestors without K but you
+                // could also break or panic
+                continue;
+            }
+
+            // SAFETY:
+            // - `observers` come from `world` and match the event type `E`, enforced by the call to `trigger`
+            // - the passed in event pointer comes from `event`, which is an `Event`
+            // - `trigger` is a matching trigger type, as it comes from `self`, which is the Trigger for `E`
+            // - `trigger_context`'s event_key matches `E`, enforced by the call to `trigger`
+            unsafe {
+                let target = self.event_target;
+                trigger_entity_internal(
+                    world.reborrow(),
+                    observers,
+                    event.into(),
+                    self.into(),
+                    target,
+                    trigger_context,
+                );
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 
 /// Prelude module to import all necessary traits and types for [`Kind`] semantics.
 pub mod prelude {
+    pub use crate::instance_trigger::InstanceTrigger;
     pub use crate::{CastInto, Kind};
     pub use crate::{
         ComponentInstance, InsertInstance, InsertInstanceWorld, SpawnInstance, SpawnInstanceWorld,
@@ -12,6 +13,7 @@ pub mod prelude {
 }
 
 mod instance;
+mod instance_trigger;
 
 use bevy_ecs::world::DeferredWorld;
 use bevy_reflect::Reflect;
@@ -84,13 +86,13 @@ pub trait CastInto<T: Kind>: Kind {
     unsafe fn cast(instance: Instance<Self>) -> Instance<T> {
         // SAFE: Because we said so.
         // TODO: Can we use required components to enforce this?
-        Instance::from_entity_unchecked(instance.entity())
+        unsafe { Instance::from_entity_unchecked(instance.entity()) }
     }
 }
 
 impl<T: Kind> CastInto<T> for T {
     unsafe fn cast(instance: Instance<Self>) -> Instance<T> {
-        Instance::from_entity_unchecked(instance.entity())
+        unsafe { Instance::from_entity_unchecked(instance.entity()) }
     }
 }
 


### PR DESCRIPTION
closes #11 by implemeting a custom `Trigger` that stores the `event_target` on the `Trigger` instead of the `Event`, so we dont have to unsafely mutate an `Instance`.