### PR TITLE
Update for Bevy 0.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ repository = "https://github.com/Zeenobit/moonshine_kind"
 
 [dependencies]
 disqualified = "1"
-bevy_ecs = "0.17"
-bevy_reflect = "0.17"
-bevy_utils = "0.17"
+bevy_ecs = "0.18"
+bevy_reflect = "0.18"
+bevy_utils = "0.18"
 
 [dev-dependencies]
-bevy = "0.17"
+bevy = "0.18"


### PR DESCRIPTION
I needed to update to Bevy 0.18 so asked Codex to update update moonshine_kind based on the [0.17->0.18 migration guide](https://bevy.org/learn/migration-guides/0-17-to-0-18/).

Changes look small and reasonable given the introduction of the new IS_ARCHETYPAL constant upstream.